### PR TITLE
Reframe CV for Engineering Manager role

### DIFF
--- a/CV-Marioara-Rus-EM.md
+++ b/CV-Marioara-Rus-EM.md
@@ -1,0 +1,96 @@
+# Marioara Rus
+
+**Engineering Leader**
+
+📧 marioararus93@gmail.com | 📞 +447424695020 | [LinkedIn](https://www.linkedin.com/in/marioararus/)
+
+---
+
+## About Me
+
+Engineering leader with a hands-on software development background, combining people leadership with technical depth to build high-performing teams that deliver at scale. Experienced in leading multiple engineering teams, shaping delivery practices, and fostering a culture of growth, ownership, and engineering excellence.
+
+Known for empowering engineers to do their best work, bridging technical and business stakeholders, and driving continuous improvement across team health, delivery flow, and system quality.
+
+---
+
+## Experience
+
+### Platform Engineering Lead
+**Aug 2023 – Present | Marks & Spencer**
+
+Engineering leader for the internal developer platform at Marks & Spencer, leading two platform teams (8 engineers) and influencing engineering practices across ~80 engineers serving 22+ product teams. Responsible for team growth, delivery effectiveness, and technical direction.
+
+- Led and mentored two engineering teams, setting clear expectations, coaching engineers through progression, and building a culture of ownership, psychological safety, and continuous improvement.
+- Shaped the platform vision and technical roadmap, aligning engineering priorities with business goals and driving adoption across 22+ product teams.
+- Drove CI/CD standardisation using GitHub Actions and reusable workflows, improving delivery flow and preventing £250k+ annual infrastructure overages through observability improvements.
+- Designed reusable starter kits and developer tooling that reduced new project setup from ~1 sprint to ~30 minutes, removing friction and accelerating time-to-value for product teams.
+- Partnered across engineering, security, and operations to identify and resolve developer workflow bottlenecks, championing a DevOps mindset and continuous delivery practices.
+- Navigated complex stakeholder landscapes across Product, UX, and other engineering domains, ensuring alignment and smooth collaboration on cross-cutting platform initiatives.
+
+### Engineering & Product Lead
+**May 2022 – Jul 2023 | Imagine Curve**
+
+Led a cross-functional engineering team building and scaling a regulated credit product from zero to one. Owned technical direction, team delivery, and stakeholder alignment across engineering, compliance, and operations in a fast-moving fintech environment.
+
+- Led and coached the engineering team through high-stakes delivery in a regulated environment, balancing feature development, technical debt, and compliance requirements.
+- Improved credit decision reliability by 50% by partnering with engineers to prioritise and resolve critical technical debt, fostering a quality-first engineering culture.
+- Guided the team through the Open Banking integration, enabling automated income verification and launching in Lithuania, reducing manual processes by 80%.
+- Ran A/B experiments on onboarding flows, driving data-informed decisions that increased approved lending by 10%.
+- Analysed funnel metrics and customer feedback to identify systemic issues, empowering the team to ship targeted improvements that increased completion and approval rates.
+- Built strong cross-functional relationships with compliance, operations, and customer support, ensuring engineering decisions were well-informed and aligned with business needs.
+
+### Software Engineer
+**March 2021 – May 2022 | Imagine Curve**
+
+Built and maintained the Credit feature in Curve's Android app, contributing to core lending functionality and integrating payment messaging systems (ISO 20022, XML, CSV) and Braze customer communication workflows. Collaborated closely with product and compliance to shape technical decisions.
+
+### Software Engineer
+**November 2019 – February 2021 | Droplet**
+
+Built the Android app from concept to Play Store launch, implementing messaging and team collaboration features.
+
+- Joined as the first employee and helped scale the engineering team from 3 to 12 people, mentoring junior developers and shaping early engineering practices.
+
+### Software Engineer
+**January 2018 – October 2019 | Qualteh**
+
+- Developed Android applications including a medical appointment booking platform with real-time doctor availability and notifications.
+- Built a job application mobile app used by supermarket customers to apply for roles and provide in-store feedback.
+
+### Software Engineer
+**Jun 2016 – Dec 2017 | Continental Automotive Timisoara**
+
+Analysed customer requirements, designed software component solutions, implemented and tested them on PC and target C systems, and delivered them for integration into production automotive projects.
+
+---
+
+## Education
+
+- **MProf in Psychotherapy**, Regent's University London — Part-time, January 2026 – Present
+- **Foundation Degree: Psychotherapy and Counselling**, Regent's University London — January 2025 – November 2025
+- **MBA: Administration and Entrepreneurship Management**, Politehnica University of Timisoara — October 2016 – July 2018
+- **Faculty of Engineering**, Technical University of Cluj-Napoca, Baia Mare — October 2012 – July 2016
+
+---
+
+## Skills
+
+**People & Engineering Leadership**
+Team coaching & mentoring, career development, building psychological safety, scaling engineering teams, fostering ownership and accountability
+
+**Delivery & Ways of Working**
+Cross-team delivery, dependency management, CI/CD automation, DevOps practices, experimentation, KPI-driven improvement
+
+**Stakeholder & Cross-Functional Collaboration**
+Partnering across Product, UX, Engineering, Security, Compliance, and Operations to align on shared objectives
+
+**Technical Background**
+Android, Kotlin, Java, GraphQL, GitHub Actions, CI/CD pipelines, platform engineering, regulated systems
+
+---
+
+## Languages
+
+- **English** — Work proficiency
+- **Romanian** — Native

--- a/CV-Marioara-Rus-EM.md
+++ b/CV-Marioara-Rus-EM.md
@@ -1,6 +1,6 @@
 # Marioara Rus
 
-**Engineering Leader**
+**Engineering Product Leader**
 
 📧 marioararus93@gmail.com | 📞 +447424695020 | [LinkedIn](https://www.linkedin.com/in/marioararus/)
 
@@ -8,7 +8,7 @@
 
 ## About Me
 
-Engineering leader with a hands-on software development background, combining people leadership with technical depth to build high-performing teams that deliver at scale. Experienced in leading multiple engineering teams, shaping delivery practices, and fostering a culture of growth, ownership, and engineering excellence.
+Product leader with a hands-on software development background, combining people leadership with technical depth to build high-performing teams that deliver at scale. Experienced in leading multiple engineering teams, shaping delivery practices, and fostering a culture of growth, ownership, and engineering excellence.
 
 Known for empowering engineers to do their best work, bridging technical and business stakeholders, and driving continuous improvement across team health, delivery flow, and system quality.
 
@@ -16,19 +16,19 @@ Known for empowering engineers to do their best work, bridging technical and bus
 
 ## Experience
 
-### Platform Engineering Lead
+### Platform Product Manager
 **Aug 2023 – Present | Marks & Spencer**
 
-Engineering leader for the internal developer platform at Marks & Spencer, leading two platform teams (8 engineers) and influencing engineering practices across ~80 engineers serving 22+ product teams. Responsible for team growth, delivery effectiveness, and technical direction.
+Product leader for the internal developer platform at Marks & Spencer, leading two platform teams (8 engineers) and influencing engineering practices across ~80 engineers serving 22+ product teams. Responsible for team growth, delivery effectiveness, and technical direction.
 
-- Led and mentored two engineering teams, setting clear expectations, coaching engineers through progression, and building a culture of ownership, psychological safety, and continuous improvement.
+- Led two engineering teams, setting clear expectations and building a culture of ownership, psychological safety, and continuous improvement.
 - Shaped the platform vision and technical roadmap, aligning engineering priorities with business goals and driving adoption across 22+ product teams.
 - Drove CI/CD standardisation using GitHub Actions and reusable workflows, improving delivery flow and preventing £250k+ annual infrastructure overages through observability improvements.
 - Designed reusable starter kits and developer tooling that reduced new project setup from ~1 sprint to ~30 minutes, removing friction and accelerating time-to-value for product teams.
 - Partnered across engineering, security, and operations to identify and resolve developer workflow bottlenecks, championing a DevOps mindset and continuous delivery practices.
 - Navigated complex stakeholder landscapes across Product, UX, and other engineering domains, ensuring alignment and smooth collaboration on cross-cutting platform initiatives.
 
-### Engineering & Product Lead
+### Product Manager
 **May 2022 – Jul 2023 | Imagine Curve**
 
 Led a cross-functional engineering team building and scaling a regulated credit product from zero to one. Owned technical direction, team delivery, and stakeholder alignment across engineering, compliance, and operations in a fast-moving fintech environment.
@@ -40,12 +40,12 @@ Led a cross-functional engineering team building and scaling a regulated credit 
 - Analysed funnel metrics and customer feedback to identify systemic issues, empowering the team to ship targeted improvements that increased completion and approval rates.
 - Built strong cross-functional relationships with compliance, operations, and customer support, ensuring engineering decisions were well-informed and aligned with business needs.
 
-### Software Engineer
+### Android Software Engineer
 **March 2021 – May 2022 | Imagine Curve**
 
 Built and maintained the Credit feature in Curve's Android app, contributing to core lending functionality and integrating payment messaging systems (ISO 20022, XML, CSV) and Braze customer communication workflows. Collaborated closely with product and compliance to shape technical decisions.
 
-### Software Engineer
+### Android Software Engineer
 **November 2019 – February 2021 | Droplet**
 
 Built the Android app from concept to Play Store launch, implementing messaging and team collaboration features.
@@ -58,7 +58,7 @@ Built the Android app from concept to Play Store launch, implementing messaging 
 - Developed Android applications including a medical appointment booking platform with real-time doctor availability and notifications.
 - Built a job application mobile app used by supermarket customers to apply for roles and provide in-store feedback.
 
-### Software Engineer
+### Embeded Software Engineer
 **Jun 2016 – Dec 2017 | Continental Automotive Timisoara**
 
 Analysed customer requirements, designed software component solutions, implemented and tested them on PC and target C systems, and delivered them for integration into production automotive projects.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <header>
       <div id="name-wrapper">
         <div id="fullname">Marioara Rus</div>
-        <div id="jobtitle">Technical Product Manager</div>
+        <div id="jobtitle">Engineering Leader</div>
       </div>
 
       <div id="contact">
@@ -40,9 +40,9 @@
       <div class="section-content">
         <div class="block">
           <div class="block-content">
-            Product Manager with an engineering background, specialising in regulated financial products, onboarding journeys, and developer platforms, building scalable systems that improve conversion, reliability, and operational efficiency.
+            Engineering leader with a hands-on software development background, combining people leadership with technical depth to build high-performing teams that deliver at scale. Experienced in leading multiple engineering teams, shaping delivery practices, and fostering a culture of growth, ownership, and engineering excellence.
             <br><br>
-            Known for bridging engineering, compliance, and business teams to translate complex systems into simple, reliable products delivered end-to-end with measurable impact.
+            Known for empowering engineers to do their best work, bridging technical and business stakeholders, and driving continuous improvement across team health, delivery flow, and system quality.
           </div>
         </div>
       </div>
@@ -53,60 +53,58 @@
       <div class="section-content">
 
         <div class="block">
-          <div class="block-title">Platform Product Manager</div>
+          <div class="block-title">Platform Engineering Lead</div>
           <div class="block-subtitle">Aug 2023 - Present | Marks &amp; Spencer</div>
           <div class="block-content">
-            Product Manager for the internal developer platform used by 22+ product teams at Marks &amp; Spencer, owning discovery, vision, and roadmap for two platform teams (8 engineers) and influencing platform strategy across ~80 engineers.
-            <br><br>
-            Defined the platform vision to address fragmented developer tooling across frontend teams, standardising CI/CD and introducing reusable workflows to reduce operational complexity.
+            Engineering leader for the internal developer platform at Marks &amp; Spencer, leading two platform teams (8 engineers) and influencing engineering practices across ~80 engineers serving 22+ product teams. Responsible for team growth, delivery effectiveness, and technical direction.
             <ul>
-              <li>Owned multiple platform capabilities used by 22+ product teams, defining the roadmap and tracking adoption, delivery speed, and operational cost metrics to guide continuous improvement.</li>
-              <li>Designed reusable workflows and starter kits that reduced setup time from ~1 sprint to ~30 minutes, accelerating new product development and time-to-value.</li>
-              <li>Standardised CI/CD using GitHub Actions and reusable templates, with observability improvements preventing &pound;250k+ annual infrastructure overages.</li>
-              <li>Partnered with engineering, security, and operations to identify developer workflow bottlenecks and deliver platform improvements.</li>
+              <li>Led and mentored two engineering teams, setting clear expectations, coaching engineers through progression, and building a culture of ownership, psychological safety, and continuous improvement.</li>
+              <li>Shaped the platform vision and technical roadmap, aligning engineering priorities with business goals and driving adoption across 22+ product teams.</li>
+              <li>Drove CI/CD standardisation using GitHub Actions and reusable workflows, improving delivery flow and preventing &pound;250k+ annual infrastructure overages through observability improvements.</li>
+              <li>Designed reusable starter kits and developer tooling that reduced new project setup from ~1 sprint to ~30 minutes, removing friction and accelerating time-to-value for product teams.</li>
+              <li>Partnered across engineering, security, and operations to identify and resolve developer workflow bottlenecks, championing a DevOps mindset and continuous delivery practices.</li>
+              <li>Navigated complex stakeholder landscapes across Product, UX, and other engineering domains, ensuring alignment and smooth collaboration on cross-cutting platform initiatives.</li>
             </ul>
           </div>
         </div>
 
         <div class="block">
-          <div class="block-title">Product Manager</div>
+          <div class="block-title">Engineering &amp; Product Lead</div>
           <div class="block-subtitle">May 2022 - Jul 2023 | Imagine Curve</div>
           <div class="block-content">
-            Led a cross-functional team responsible for building and scaling a regulated credit product from zero to one, owning the product end-to-end across discovery, delivery, regulatory alignment, and performance tracking.
-            <br><br>
-            Owned product strategy and delivery for the Credit product, working closely with engineering, compliance, and operations to balance feature development, technical improvements, and regulatory requirements.
+            Led a cross-functional engineering team building and scaling a regulated credit product from zero to one. Owned technical direction, team delivery, and stakeholder alignment across engineering, compliance, and operations in a fast-moving fintech environment.
             <ul>
-              <li>Owned the Credit (Flex) product across EEA markets, balancing regulatory, compliance, and customer needs in a highly regulated financial environment.</li>
-              <li>Led the Open Banking integration for the Credit product, enabling automated income verification and launching the product in Lithuania, reducing manual credit checks by 80%.</li>
-              <li>Ran A/B experiments on the credit onboarding flow, reducing drop-off and increasing approved lending by 10%.</li>
-              <li>Analysed onboarding funnel metrics to identify key drop-off points in the credit application journey, prioritising improvements that increased application completion and approval efficiency.</li>
-              <li>Improved credit decision reliability by 50% by partnering with engineering to address key technical debt and stabilise core lending flows.</li>
-              <li>Conducted user interviews and analysed customer support feedback to understand why applicants abandoned the credit journey, informing UX improvements that reduced onboarding friction.</li>
+              <li>Led and coached the engineering team through high-stakes delivery in a regulated environment, balancing feature development, technical debt, and compliance requirements.</li>
+              <li>Improved credit decision reliability by 50% by partnering with engineers to prioritise and resolve critical technical debt, fostering a quality-first engineering culture.</li>
+              <li>Guided the team through the Open Banking integration, enabling automated income verification and launching in Lithuania, reducing manual processes by 80%.</li>
+              <li>Ran A/B experiments on onboarding flows, driving data-informed decisions that increased approved lending by 10%.</li>
+              <li>Analysed funnel metrics and customer feedback to identify systemic issues, empowering the team to ship targeted improvements that increased completion and approval rates.</li>
+              <li>Built strong cross-functional relationships with compliance, operations, and customer support, ensuring engineering decisions were well-informed and aligned with business needs.</li>
             </ul>
           </div>
         </div>
 
         <div class="block">
-          <div class="block-title">Android Developer</div>
+          <div class="block-title">Software Engineer</div>
           <div class="block-subtitle">March 2021 - May 2022 | Imagine Curve</div>
           <div class="block-content">
-            Built and maintained the Credit feature in Curve&rsquo;s Android app, contributing to core lending functionality and integrating payment messaging systems (ISO 20022, XML, CSV) and Braze customer communication workflows.
+            Built and maintained the Credit feature in Curve&rsquo;s Android app, contributing to core lending functionality and integrating payment messaging systems (ISO 20022, XML, CSV) and Braze customer communication workflows. Collaborated closely with product and compliance to shape technical decisions.
           </div>
         </div>
 
         <div class="block">
-          <div class="block-title">Android Developer</div>
+          <div class="block-title">Software Engineer</div>
           <div class="block-subtitle">November 2019 - February 2021 | Droplet</div>
           <div class="block-content">
             Built the Android app from concept to Play Store launch, implementing messaging and team collaboration features.
             <ul>
-              <li>Joined as the first employee and helped scale the team from 3 to 12 people, mentoring junior developers.</li>
+              <li>Joined as the first employee and helped scale the engineering team from 3 to 12 people, mentoring junior developers and shaping early engineering practices.</li>
             </ul>
           </div>
         </div>
 
         <div class="block">
-          <div class="block-title">Android Developer</div>
+          <div class="block-title">Software Engineer</div>
           <div class="block-subtitle">January 2018 - October 2019 | Qualteh</div>
           <div class="block-content">
             <ul>
@@ -155,23 +153,23 @@
       <div class="section-content">
 
         <div class="block">
-          <div class="block-title">Product Leadership</div>
-          <div class="block-content">Product strategy, roadmap ownership, experimentation, KPI tracking</div>
+          <div class="block-title">People &amp; Engineering Leadership</div>
+          <div class="block-content">Team coaching &amp; mentoring, career development, building psychological safety, scaling engineering teams, fostering ownership and accountability</div>
         </div>
 
         <div class="block">
-          <div class="block-title">Fintech &amp; Platform Products</div>
-          <div class="block-content">Regulated financial products, onboarding journeys, developer platforms, CI/CD automation</div>
+          <div class="block-title">Delivery &amp; Ways of Working</div>
+          <div class="block-content">Cross-team delivery, dependency management, CI/CD automation, DevOps practices, experimentation, KPI-driven improvement</div>
         </div>
 
         <div class="block">
-          <div class="block-title">Cross-Functional Leadership</div>
-          <div class="block-content">Engineering, design, data, security, compliance, operations</div>
+          <div class="block-title">Stakeholder &amp; Cross-Functional Collaboration</div>
+          <div class="block-content">Partnering across Product, UX, Engineering, Security, Compliance, and Operations to align on shared objectives</div>
         </div>
 
         <div class="block">
           <div class="block-title">Technical Background</div>
-          <div class="block-content">Android, Kotlin, Java, GraphQL, CI/CD, GitHub Actions</div>
+          <div class="block-content">Android, Kotlin, Java, GraphQL, GitHub Actions, CI/CD pipelines, platform engineering, regulated systems</div>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary

Reframes the CV from a Product Manager positioning to an Engineering Manager lens, targeting the M&S Web Experience EM role.

### Changes
- **Title & About** → "Engineering Leader" with focus on people leadership, team culture, and engineering excellence
- **M&S role** → "Platform Engineering Lead" — highlights mentoring, coaching, psychological safety, stakeholder navigation
- **Curve role** → "Engineering & Product Lead" — emphasises leading and coaching engineering teams through high-stakes delivery
- **Earlier roles** → Unified as "Software Engineer" for a cleaner engineering career arc
- **Skills** → Restructured around People & Engineering Leadership, Delivery & Ways of Working, Stakeholder Collaboration, and Technical Background
- **Added** `CV-Marioara-Rus-EM.md` — markdown export for easy sharing